### PR TITLE
FOVRecurse: Bug fix case 5: map length check looking for wrong index

### DIFF
--- a/FOVRecurse.cs
+++ b/FOVRecurse.cs
@@ -288,12 +288,12 @@ namespace map
 
                             if (map[x, y] == 1)
                             {
-                                if (x + 1 < map.GetLength(1) && map[x+1, y] == 0)
+                                if (x + 1 < map.GetLength(0) && map[x+1, y] == 0)
                                     ScanOctant(pDepth + 1, pOctant, pStartSlope, GetSlope(x + 0.5, y - 0.5, player.X, player.Y, false));
                             }
                             else
                             {
-                                if (x + 1 < map.GetLength(1)
+                                if (x + 1 < map.GetLength(0)
                                         && map[x + 1, y] == 1)
                                     pStartSlope = GetSlope(x + 0.5, y + 0.5, player.X, player.Y, false);
 


### PR DESCRIPTION
I was trying your FOVRecurse component and found a bug in some corner case with non-square maps. Here is the fix.

Besides that, it works great.
Thanks!